### PR TITLE
Adding 3-step line reference JSON output

### DIFF
--- a/src/models/claude_withref_async.py
+++ b/src/models/claude_withref_async.py
@@ -122,7 +122,7 @@ if __name__ == "__main__":
     interview_name = "interview_1090"
     interviews_directory = os.path.join(data_directory, interview_name)
     guidelines_path = os.path.join(data_directory, f"{interview_name}_guidelines.csv")
-    pipeline_name = "rag_sumrag_async"
+    pipeline_name = "claude_withref_async"
     conciseness = 1
 
     output_path = os.path.join(project_root, "results", f"{pipeline_name}_{interview_name}.csv")

--- a/src/models/claude_withref_async.py
+++ b/src/models/claude_withref_async.py
@@ -108,7 +108,8 @@ async def main(transcript_dir: str, guidelines_path: str, llm_model: str, pipeli
         #     print("*"*30)  
         #     print() 
     await generate_output_from_summarized_matches_async(
-        transcript_files, matches_list, guide_questions, llm_model, output_path, conciseness=conciseness, logger=logger
+        transcript_files, matches_list, guide_questions, llm_model, output_path, conciseness=conciseness, logger=logger,
+        embedding_model=model, device=device
     )
 
 
@@ -126,7 +127,6 @@ if __name__ == "__main__":
     conciseness = 1
 
     output_path = os.path.join(project_root, "results", f"{pipeline_name}_{interview_name}.csv")
-    #llm_model = "claude-3-5-haiku-20241022"
     llm_model = "claude-3-5-haiku-20241022"
 
     start_time = time.time()

--- a/src/models/claude_withref_async.py
+++ b/src/models/claude_withref_async.py
@@ -1,0 +1,143 @@
+import sys
+import os
+import asyncio
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+from src.utils.data_utils import load_guidelines, load_transcript, segment_transcript
+from src.utils.embedding_utils import embed_groups, match_top_p_questions
+from src.utils.output_utils import generate_output_from_summarized_matches_async, setup_logging, output_divider
+from src.utils.api_utils import summarize_question_async
+from sentence_transformers import SentenceTransformer
+import torch
+from glob import glob
+from dotenv import load_dotenv
+import time
+
+async def main(transcript_dir: str, guidelines_path: str, llm_model: str, pipeline_name: str, output_path: str,
+               disable_logging: bool = False, conciseness: int = 0):
+    """
+    Main execution function to process transcripts using summarized question embeddings.
+
+    Args:
+        transcript_dir (str): Directory containing transcript files.
+        guidelines_path (str): Path to the guidelines CSV file.
+        llm_model (str): The GPT model to use.
+        output_path (str): Path for the output CSV file.
+        disable_logging (bool): Whether to disable logging.
+        conciseness (int): Conciseness level (0 for less concise, 1 for more concise).
+    """
+    # Set up logging
+    logger = setup_logging(pipeline_name, output_path, disable_logging=disable_logging)
+
+    logger.info("Summarizing pipeline started ...")
+    logger.info(f"Start finding matches for guidelines: {guidelines_path.split('/')[-1]}")
+    output_divider(logger, True)
+
+    device = torch.device(
+        "mps" if torch.backends.mps.is_available()
+        else "cuda" if torch.cuda.is_available()
+        else "cpu"
+    )
+
+    os.environ["TOKENIZERS_PARALLELISM"] = "false"
+    model = SentenceTransformer("sentence-transformers/nli-roberta-base-v2", device=device)
+
+    guide_questions = load_guidelines(guidelines_path)
+
+    transcript_files = glob(os.path.join(transcript_dir, "*.txt"))
+    if not transcript_files:
+        raise FileNotFoundError("No transcript files found in directory")
+
+    # Precompute embeddings for guide questions
+    logger.info("Summarizing and embedding guide questions...")
+    guide_question_data = []
+    semaphore = asyncio.Semaphore(1)  # Limit to 10 concurrent API calls
+
+    async def summarize_with_limit(question):
+        async with semaphore:
+            return await summarize_question_async(question, None, logger)
+
+    tasks = [summarize_with_limit(guide_question) for guide_question in guide_questions]
+    summarized_questions = await asyncio.gather(*tasks)
+
+    for guide_question, summarized_guide_question in zip(guide_questions, summarized_questions):
+        question_embedding = model.encode(summarized_guide_question, convert_to_tensor=True, device=device)
+        guide_question_data.append({
+            "guide_question": guide_question,
+            "summarized_guide_question": summarized_guide_question,
+            "embedding": question_embedding
+        })
+
+    logger.info("Guide question embeddings precomputed.")
+    output_divider(logger, True)
+
+    matches_list = []
+
+    for transcript_path in transcript_files:
+        logger.info(f"Processing transcript: {transcript_path.split('/')[-1]}")
+        transcript = load_transcript(transcript_path)
+
+        groups = segment_transcript(transcript)
+        group_embeddings = embed_groups(groups, model, device)
+
+        # print(f"File: {transcript_path}")
+        # print()
+        # for g in group_embeddings:
+        #     print(g['embedding'][:5])
+        #     for k in g.keys():
+        #         if k !='embedding':
+        #             print(f'{k}: ', g[k])
+        #     print(end=f"\n{'-'*20}\n\n") # end of group
+        # print("*"*30)     
+
+        transcript_matches = []
+        for guide_data in guide_question_data:
+            top_matches = match_top_p_questions(guide_data["embedding"], group_embeddings, p=0.5)
+            transcript_matches.append({
+                "guide_question": guide_data["guide_question"],
+                "matches": top_matches
+            })
+        matches_list.append(transcript_matches)
+
+        # for tm in transcript_matches:
+        #     print(f"Guide Question: ", tm["guide_question"], end='\n\n')
+        #     for top_p in tm["matches"]:
+        #         print(f"{top_p['similarity']:.4f}")
+        #         print(f"{top_p['speaking_round']}")
+        #         print(f'{top_p['interviewer_line_ref']:>3} - Interviewer: ', top_p['question'])
+        #         print(f'{top_p['interviewee_line_ref']:>3} - Interviewee: ', top_p['response'], end=f"\n{'-'*20}\n\n")
+        #     print("*"*30)  
+        #     print() 
+    await generate_output_from_summarized_matches_async(
+        transcript_files, matches_list, guide_questions, llm_model, output_path, conciseness=conciseness, logger=logger
+    )
+
+
+if __name__ == "__main__":
+    load_dotenv()
+
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    project_root = os.path.abspath(os.path.join(script_dir, "..", ".."))
+    data_directory = os.path.join(project_root, "data", "private_data")
+    
+    interview_name = "interview_1090"
+    interviews_directory = os.path.join(data_directory, interview_name)
+    guidelines_path = os.path.join(data_directory, f"{interview_name}_guidelines.csv")
+    pipeline_name = "rag_sumrag_async"
+    conciseness = 1
+
+    output_path = os.path.join(project_root, "results", f"{pipeline_name}_{interview_name}.csv")
+    #llm_model = "claude-3-5-haiku-20241022"
+    llm_model = "claude-3-5-haiku-20241022"
+
+    start_time = time.time()
+
+    # Run the async main function
+    asyncio.run(main(
+        interviews_directory, guidelines_path, llm_model, pipeline_name, output_path,
+        disable_logging=False, conciseness=conciseness
+    ))
+
+    end_time = time.time()
+
+    elapsed_time = end_time - start_time
+    print(f"Time taken: {elapsed_time:.4f} seconds")

--- a/src/models/rag_sumrag_async.py
+++ b/src/models/rag_sumrag_async.py
@@ -91,7 +91,8 @@ async def main(transcript_dir: str, guidelines_path: str, llm_model: str, pipeli
         matches_list.append(transcript_matches)
 
     await generate_output_from_summarized_matches_async(
-        transcript_files, matches_list, guide_questions, llm_model, output_path, conciseness=conciseness, logger=logger
+        transcript_files, matches_list, guide_questions, llm_model, output_path, conciseness=conciseness, logger=logger,
+        embedding_model=model, device=device
     )
 
 

--- a/src/utils/api_utils.py
+++ b/src/utils/api_utils.py
@@ -73,6 +73,12 @@ async def extract_and_summarize_response_llm_async(context: str, query: str, llm
 
     # First call: Extract the core phrase from the interviewee's response
     try:
+        if len(context.strip())==0:
+            # no matches using p
+            logger.info("Line Referencing: No matching dialog, appending [No relevant response found]")
+            # this could be a different string, if we need to debug/differentiate
+            return "[No relevant response found]"
+        
         extract_prompt = build_extract_prompt(context, query, conciseness)
         response = await acompletion(
             model=llm_model,

--- a/src/utils/api_utils.py
+++ b/src/utils/api_utils.py
@@ -121,14 +121,19 @@ async def summarize_question_async(question: str, llm_model: str, logger: loggin
     prompt = f"""Summarize the following question into a concise, single sentence that captures its core intent, 
                 avoiding greetings, filler words and maintaining clarity: "{question}" """
     try:
-        response = await acompletion(
-            model=llm_model,
-            messages=[
-                {"role": "system", "content": "You are a helpful assistant."},
-                {"role": "user", "content": prompt}
-            ]
-        )
-        summarized_question = response.choices[0].message.content.strip('\"\'')
+        if llm_model:
+            response = await acompletion(
+                model=llm_model,
+                messages=[
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": prompt}
+                ]
+            )
+            summarized_question = response.choices[0].message.content.strip('\"\'')
+        else:
+            # you can pass None for llm_model for an "Identity" summary i.e. copied directly
+            summarized_question = question
+        
         logger.info("Original Question: %s", question)
         logger.info("Summarized Question: %s", f"{summarized_question}\n")
         return summarized_question

--- a/src/utils/api_utils.py
+++ b/src/utils/api_utils.py
@@ -102,7 +102,7 @@ async def extract_and_summarize_response_llm_async(context: str, query: str, llm
                 temperature=0
             )
             response_content = response.choices[0].message.content.strip('\"\'')
-            return response_content
+            return (response_content, extracted_phrase)
         except Exception as e:
             logger.error(f"Error summarizing response: {str(e)}")
             return f"Error querying ChatGPT: {str(e)}"

--- a/src/utils/embedding_utils.py
+++ b/src/utils/embedding_utils.py
@@ -53,7 +53,10 @@ def match_top_k_questions(guide_question: str, group_embeddings: list[dict], mod
         similarities.append({
             "response": group["interviewee_response"],
             "question": group["interviewer_question"],
-            "similarity": float(similarity)
+            "similarity": float(similarity),
+            "interviewer_line_ref": group["interviewer_line_ref"],
+            "interviewee_line_ref": group["interviewee_line_ref"],
+            "speaking_round": group["speaking_round"]
         })
     similarities.sort(key=lambda x: x["similarity"], reverse=True)
     return similarities[:k]
@@ -98,7 +101,10 @@ async def summarize_embed_groups_async(groups: list[dict], model: SentenceTransf
             "original_question": original_question,
             "summarized_question": summarized_question,
             "original_response": " ".join(group["interviewee"]).replace("Interviewee: ", ""),
-            "embedding": embedding
+            "embedding": embedding,
+            "interviewer_line_ref": group["interviewer_line_ref"],
+            "interviewee_line_ref": group["interviewee_line_ref"],
+            "speaking_round": group["speaking_round"]
         })
 
     logger.info("Questions summarized and embedded.")
@@ -128,7 +134,10 @@ async def summarize_match_top_k_questions_async(guide_embedding: torch.Tensor, g
         similarities.append({
             "response": group["original_response"],
             "question": group["original_question"],
-            "similarity": float(similarity)
+            "similarity": float(similarity),
+            "interviewer_line_ref": group["interviewer_line_ref"],
+            "interviewee_line_ref": group["interviewee_line_ref"],
+            "speaking_round": group["speaking_round"]
         })
     similarities.sort(key=lambda x: x["similarity"], reverse=True)
     return similarities[:k]


### PR DESCRIPTION
- Resolve #45 by including line references when reading 4f0c4313d848d516c9df05f7a0d5f37c2b7c906f
- Resolve #46 by capturing original response from LLM (before summarization) and searching for it in the transcript  for an exact match e46837ffbf433721fa9a980b29129263d6d39306 and 1a1d73f7cc0b1bba88fcbe2b3b5cf660d8d12e96
- Implemented a model with Claude LLM to test the async functionality. Closes #58 in c0f88ca9e0b54db04d8c54cac8727b549f341e70
- Resolve #68 by embedding the interviewee responses and using the extracted phrase to find a similarity match in case exact match is not found, as step 2. 2351bbe and 686d2f3
- Resolve #69 by implementing fallback step to use all relevant lines if no exact match is found, and no interviewee response with similarity score >0.8 is found 91e6c09