### PR TITLE
Handling LLM API error

### DIFF
--- a/src/d2d/processor.py
+++ b/src/d2d/processor.py
@@ -302,7 +302,6 @@ class D2DProcessor:
         except Exception as e:
             logger.info(f"Error embedding file {transcript_path.split('/')[-1]} due to {e}")
             return []
-        #TODO: Check
         
 
         # Check thematic alignment between transcript and guideline

--- a/src/d2d/processor.py
+++ b/src/d2d/processor.py
@@ -149,8 +149,13 @@ class D2DProcessor:
 
         # Precompute embeddings for guide questions
         logger.info("Summarizing and embedding guide questions...")
-        guide_question_data = await self._summarize_guide_questions(guide_questions, logger)
-        logger.info("Guide question embeddings precomputed.")
+
+        try:
+            guide_question_data = await self._summarize_guide_questions(guide_questions, logger)
+            logger.info("Guide question embeddings precomputed.")
+        except Exception as e:
+            logger.error(f"Error computing Guide question embeddings {e}")
+            return
         output_divider(logger, True)
 
         # Process each transcript and filter out skipped ones
@@ -201,10 +206,26 @@ class D2DProcessor:
                 return await summarize_question_async(question, self.llm_model, logger)
 
         tasks = [summarize_with_limit(q) for q in guide_questions]
-        summarized_questions = await asyncio.gather(*tasks)
+        summarized_questions = await asyncio.gather(*tasks, return_exceptions=True)
+
+        # check for task errors
+        error_results = [e for e in summarized_questions if isinstance(e, Exception)]
+        good_results = [r for r in summarized_questions if not isinstance(r, Exception)]
+
+        if len(good_results)==0 and len(error_results)>0:
+            error_list = set([e.__class__.__qualname__ for e in error_results])
+            logger.error(f"All Guide Question Summarizing tasks returned errors of type: {error_list}")
+            raise error_results[0]
+        elif len(error_results)>0:
+            logger.warning("Some Guide Question Summarizing tasks in have errors.")
 
         guide_question_data = []
         for guide_question, summarized_question in zip(guide_questions, summarized_questions):
+            # Fallback to original question if this instance resulted in an error
+            if isinstance(summarized_question, Exception):
+                logger.error(f"Error summarizing guide question '{guide_question}': {str(summarized_question)}")
+                summarized_question = guide_question  
+
             embedding = self.embedding_model.encode(summarized_question, convert_to_tensor=True, device=self.device)
             guide_question_data.append({
                 "guide_question": guide_question,
@@ -274,9 +295,15 @@ class D2DProcessor:
 
         # Summarize and embed the interviewer questions and interviewee responses for each group
         # Uses the LLM to summarize questions and SentenceTransformer to generate embeddings
-        group_embeddings = await summarize_embed_groups_async(
-            groups, self.embedding_model, self.device, self.llm_model, logger
-        )
+        try:
+            group_embeddings = await summarize_embed_groups_async(
+                groups, self.embedding_model, self.device, self.llm_model, logger
+                )
+        except Exception as e:
+            logger.info(f"Error embedding file {transcript_path.split('/')[-1]} due to {e}")
+            return []
+        #TODO: Check
+        
 
         # Check thematic alignment between transcript and guideline
         logger.info("Checking thematic alignment between transcript and guideline...")

--- a/src/d2d/processor.py
+++ b/src/d2d/processor.py
@@ -155,7 +155,7 @@ class D2DProcessor:
             logger.info("Guide question embeddings precomputed.")
         except Exception as e:
             logger.error(f"Error computing Guide question embeddings {e}")
-            return
+            raise e
         output_divider(logger, True)
 
         # Process each transcript and filter out skipped ones
@@ -217,7 +217,7 @@ class D2DProcessor:
             logger.error(f"All Guide Question Summarizing tasks returned errors of type: {error_list}")
             raise error_results[0]
         elif len(error_results)>0:
-            logger.warning("Some Guide Question Summarizing tasks in have errors.")
+            logger.warning("Some Guide Question Summarizing tasks have errors.")
 
         guide_question_data = []
         for guide_question, summarized_question in zip(guide_questions, summarized_questions):

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -37,7 +37,7 @@ def test_csv_valid_interview_default(subtests, test_case_files):
         data_dir=str(temp_folder),
         interview_name=f"interview_{test_case}",
         output_dir=output_folder,
-        disable_logging=False
+        disable_logging_to_console=True
     )
 
     # check that the output folder exists - should be True
@@ -137,7 +137,7 @@ def test_csv_valid_interview_plus_empty(subtests, test_case_files_with_extra_fil
         data_dir=str(temp_folder),
         interview_name=f"interview_{test_case}",
         output_dir=output_folder,
-        disable_logging=False
+        disable_logging_to_console=True
     )
 
     # check that the output folder exists - should be True
@@ -199,7 +199,7 @@ def test_csv_valid_interview_top_p(subtests, test_case_files):
         data_dir=str(temp_folder),
         interview_name=f"interview_{test_case}",
         output_dir=output_folder,
-        disable_logging=False
+        disable_logging_to_console=True
     )
 
     # check that the output folder exists - should be True

--- a/tests/test_processor_api.py
+++ b/tests/test_processor_api.py
@@ -40,7 +40,7 @@ def test_openai_apikey(test_case_files, setup_bad_apikey, subtests):
             data_dir=str(temp_folder),
             interview_name=f"interview_{test_case}",
             output_dir=output_folder,
-            disable_logging=False
+            disable_logging_to_console=False
         )
     
     # dump content of all files in the output folder to verify output, if needed "-s flag"


### PR DESCRIPTION

- Fixed #121 however this has to be manually tested as creating a pytest for it would take more time 
- Fixed #122 and added test case for incorrect API keys
- Fixed #124 and added a test cases that checks error raised with binary file input specified. Manually confirmed with a PDF file